### PR TITLE
fix(error.c): remove wrong strncpy and use vsnprintf

### DIFF
--- a/src/lib/error.c
+++ b/src/lib/error.c
@@ -9,7 +9,7 @@ void est_error_update(ESTError_t *err, const char *new_message, ...) {
     va_start(args, new_message);
 
     char new_human[EST_ERROR_MSG_LEN];
-    vsprintf(new_human, new_message, args);
+    vsnprintf(new_human, EST_ERROR_MSG_LEN - 1, new_message, args);
 
     size_t concat_len = strlen(err->human) + strlen(new_human) + strlen(". ");
     size_t avail_len = EST_ERROR_MSG_LEN - strlen(err->human);
@@ -27,9 +27,8 @@ void est_error_set(ESTError_t *err, int8_t subsystem, int16_t code, const char *
     va_list args;
     va_start(args, message);
 
-    vsprintf(err->human, message, args);
+    vsnprintf(err->human, EST_ERROR_MSG_LEN - 1, message, args);
 
-    strncpy(err->human, message, EST_ERROR_MSG_LEN - 1);
     err->code = code;
     err->native = errno;
 
@@ -40,9 +39,8 @@ void est_error_set_custom(ESTError_t *err, int8_t subsystem, int16_t code, int n
     va_list args;
     va_start(args, message);
 
-    vsprintf(err->human, message, args);
+    vsnprintf(err->human, EST_ERROR_MSG_LEN - 1, message, args);
 
-    strncpy(err->human, message, EST_ERROR_MSG_LEN - 1);
     err->code = code;
     err->native = native;
 


### PR DESCRIPTION
This removes a bug where the error message is substituted with the format string and, by using vsnprintf, also possibly exploitable buffer overflows in the creation of the error string.

The bug is reproducible simply by generating some error, and you'll get printed the format string instead of the result, so something like this:
```
ERROR: Enrollment failed (code=8,native=0,subsystem=0): Invalid header %s value %s found in response
```